### PR TITLE
fix: integração MQTT firmware-backend (QoS 1 no comando + eventos de energia)

### DIFF
--- a/software/backend/src/runs/schemas.py
+++ b/software/backend/src/runs/schemas.py
@@ -43,8 +43,18 @@ class TelemetriaPayload(BaseModel):
     voltage: float | None = None
 
 
+# Tipos de evento publicados pelo firmware: ciclo de vida da corrida
+# (inicio/fim/desafio_cumprido), navegação (colisao/reparo) e alertas de energia
+# (HU21/HU16/HU10). Precisam bater com nome_evento_energia() do firmware.
+EventoType = Literal[
+    "inicio", "fim", "colisao", "reparo", "desafio_cumprido",
+    "tensao_baixa", "tensao_oscilacao", "bateria_baixa", "bateria_critica",
+    "consumo_alto", "energia",
+]
+
+
 class EventoPayload(BaseModel):
     ts: datetime
     run_id: str
-    type: Literal["inicio", "colisao", "reparo", "desafio_cumprido"]
+    type: EventoType
     detail: str = ""

--- a/software/backend/src/runs/tests/test_schemas.py
+++ b/software/backend/src/runs/tests/test_schemas.py
@@ -150,6 +150,25 @@ def test_evento_payload_reparo_valid():
     assert payload.type == "reparo"
 
 
+# Tipos publicados pelo firmware que o schema precisa aceitar (regressão do
+# contrato firmware<->backend). Espelha nome_evento_energia() + fim/inicio.
+@pytest.mark.parametrize(
+    "tipo",
+    [
+        "fim",
+        "tensao_baixa",
+        "tensao_oscilacao",
+        "bateria_baixa",
+        "bateria_critica",
+        "consumo_alto",
+        "energia",
+    ],
+)
+def test_evento_payload_tipos_do_firmware_validos(tipo):
+    payload = EventoPayload.model_validate(_valid_evento(type=tipo))
+    assert payload.type == tipo
+
+
 def test_evento_payload_invalid_type():
     with pytest.raises(ValidationError):
         EventoPayload.model_validate(_valid_evento(type="inexistente"))

--- a/software/backend/src/runs/tests/test_use_cases.py
+++ b/software/backend/src/runs/tests/test_use_cases.py
@@ -215,3 +215,24 @@ def test_registrar_evento_desafio_cumprido_fecha_tentativa():
     assert tentativa.status == Tentativa.Status.FINALIZADA
     assert tentativa.sucesso is True
     assert tentativa.tempo_fim is not None
+
+
+@pytest.mark.django_db
+def test_registrar_evento_fim_fecha_sem_sucesso():
+    # "fim" (stop) fecha a tentativa mas NÃO crava sucesso, diferença semântica
+    # de "desafio_cumprido". Trava a regressão de o branch voltar a marcar sucesso.
+    tentativa = TentativaFactory()
+    payload = {
+        "ts": datetime.now(UTC).isoformat(),
+        "run_id": str(tentativa.id),
+        "type": "fim",
+        "detail": "",
+    }
+
+    RegistrarEvento().execute(payload=payload)
+
+    tentativa.refresh_from_db()
+    assert tentativa.status == Tentativa.Status.FINALIZADA
+    assert tentativa.tempo_fim is not None
+    # fim não crava sucesso: fica no default nulo, ao contrário de desafio_cumprido.
+    assert tentativa.sucesso is None

--- a/software/backend/src/runs/use_cases/registrar_evento.py
+++ b/software/backend/src/runs/use_cases/registrar_evento.py
@@ -25,6 +25,14 @@ class RegistrarEvento:
             tentativa.tempo_fim = data.ts
             tentativa.sucesso = True
             tentativa.status = Tentativa.Status.FINALIZADA
+        elif data.type == "fim":
+            # Corrida encerrada (stop). Fecha sem cravar sucesso: o firmware
+            # só sinaliza que parou, não que cumpriu o objetivo.
+            tentativa.tempo_fim = data.ts
+            tentativa.status = Tentativa.Status.FINALIZADA
+        # Alertas de energia (tensao_baixa, bateria_*, consumo_alto) e navegação
+        # (colisao/reparo) apenas passam: são registrados no snapshot, sem mudar
+        # o ciclo de vida da tentativa.
 
         tentativa.save(
             update_fields=[

--- a/software/firmware/main.cpp
+++ b/software/firmware/main.cpp
@@ -312,6 +312,14 @@ static void handle_command(const char *payload) {
     }
 }
 
+// Confirma um PUBLISH QoS1 recebido (senão o broker reenvia indefinidamente).
+static void mqtt_puback(uint16_t packet_id) {
+    if (mqtt_sock < 0) return;
+    uint8_t pkt[4] = {0x40, 0x02,
+                      (uint8_t)(packet_id >> 8), (uint8_t)(packet_id & 0xFF)};
+    send(mqtt_sock, pkt, 4, 0);
+}
+
 // ─── Recebe e processa pacotes MQTT recebidos (não-bloqueante) ────────────────
 static void mqtt_receive(void) {
     if (mqtt_sock < 0) return;
@@ -325,10 +333,17 @@ static void mqtt_receive(void) {
         if (idx >= r) break;
         uint8_t pkt_type = (byte1 >> 4) & 0x0F;
 
-        // Lê Remaining Length (assume 1 byte para payloads pequenos)
+        // Lê Remaining Length como 1 byte. Premissa: pacote de comando < 128
+        // bytes e inteiro num único recv. Comando maior ou multi-segmento
+        // desalinharia o parser. Se o protocolo de comando crescer, tratar o
+        // Remaining Length multi-byte (MQTT §2.2.3) e manter estado entre recv.
         uint8_t rem = buf[idx++];
 
         if (pkt_type == 3) { // PUBLISH
+            // QoS nos bits 2-1 do byte fixo. Se QoS>0, ha um Packet Identifier
+            // de 2 bytes ENTRE o tópico e o payload; sem pular, o payload sai
+            // corrompido. O dashboard assina/publica em QoS1, então isso importa.
+            uint8_t qos = (byte1 >> 1) & 0x03;
             if (idx + 2 > r) break;
             uint16_t tlen = ((uint16_t)buf[idx] << 8) | buf[idx + 1];
             idx += 2;
@@ -339,14 +354,30 @@ static void mqtt_receive(void) {
             topic[copy] = '\0';
             idx += tlen;
 
-            int payload_len = rem - 2 - tlen;
+            uint16_t packet_id = 0;
+            int id_bytes = 0;
+            if (qos > 0) {
+                if (idx + 2 > r) break;
+                packet_id = ((uint16_t)buf[idx] << 8) | buf[idx + 1];
+                idx += 2;
+                id_bytes = 2;
+            }
+
+            int payload_len = rem - 2 - tlen - id_bytes;
             if (payload_len < 0) payload_len = 0;
-            if (payload_len > (int)(sizeof(buf) - idx)) payload_len = sizeof(buf) - idx;
+            // Clampa pelos bytes REALMENTE recebidos neste recv (r), não pela
+            // capacidade do buffer: sob fragmentação TCP (Wi-Fi), o rem declarado
+            // pode exceder o que chegou, e copiar até sizeof(buf) leria stack não
+            // inicializada como payload. Comando partido é descartado, não corrompido.
+            int disponivel = r - idx;
+            if (payload_len > disponivel) payload_len = disponivel;
             char payload[256] = "";
             int pl = payload_len < (int)sizeof(payload) - 1 ? payload_len : (int)sizeof(payload) - 1;
             memcpy(payload, buf + idx, pl);
             payload[pl] = '\0';
             idx += payload_len;
+
+            if (qos == 1) mqtt_puback(packet_id); // confirma a entrega
 
             handle_command(payload);
         } else {


### PR DESCRIPTION
## Contexto

Testando a integração do firmware (`software/firmware/main.cpp`) contra o backend real (mosquitto + `mqtt_subscriber` + dashboard), dois problemas impediam o fluxo ponta a ponta de funcionar. Este PR corrige os dois.

## Bug 1 - comando `start` do dashboard não era processado (QoS 1)

O firmware assina `micromouse/<id>/comando` em QoS 1 e o backend publica o `start` em QoS 1. O parser de PUBLISH recebido (`mqtt_receive`) assumia QoS 0 e não pulava o Packet Identifier de 2 bytes que existe em PUBLISH com QoS > 0. Resultado: o payload do comando chegava vazio e o robô nunca iniciava a corrida pelo dashboard.

**Fix:** ler os bits de QoS do byte fixo; quando QoS > 0, ler e pular o Packet Identifier, descontar do tamanho do payload, e enviar `PUBACK` (senão o broker reenvia o comando indefinidamente). Aproveitei também para clampar o payload pelos bytes recebidos, não pela capacidade do buffer, pra não ler além do que o `recv` entregou sob fragmentação TCP.

## Bug 2 - alertas de energia rejeitados pelo backend (contrato divergente)

O firmware publica eventos de energia (`tensao_baixa`, `tensao_oscilacao`, `bateria_baixa`, `bateria_critica`, `consumo_alto`) e `fim`, mas o `EventoPayload` do backend só aceitava `inicio/colisao/reparo/desafio_cumprido`. O subscriber rejeitava todos os alertas de energia (erro de validação) e eles nunca chegavam ao dashboard.

**Fix:** estender o tipo de evento (`EventoType`) com os alertas de energia + `fim`, e tratar `fim` fechando a tentativa (sem cravar sucesso, já que `fim` só sinaliza que a corrida parou).

## Validação

Firmware e backend testados juntos localmente: o `start` do dashboard passou a iniciar a corrida, a telemetria e os alertas de energia chegam e persistem, e o dashboard atualiza ao vivo via SSE (bateria drenando, tensão, consumo).

Testes de regressão adicionados no backend:
- `test_schemas`: o `EventoPayload` aceita `fim` e os cinco tipos de energia (espelhando `nome_evento_energia()` do firmware). Sem o fix, falha com `ValidationError`.
- `test_use_cases`: o evento `fim` fecha a tentativa sem cravar `sucesso` (distinção de `desafio_cumprido`).

## Escopo

Só a integração MQTT firmware-backend. Não toca navegação nem mapeamento (o `core1` segue como está).
